### PR TITLE
intを正しく表示させるため、UART送信をprintfに置き換えた

### DIFF
--- a/YamaHexDeviceController/Core/Src/main.c
+++ b/YamaHexDeviceController/Core/Src/main.c
@@ -26,6 +26,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include <stdbool.h>
+#include <stdio.h>
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -251,10 +252,7 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
   if (HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, &RxHeader, RxData) == HAL_OK)
   {
     int16_t data = (int16_t)(((uint16_t)RxData[1] << 8) | RxData[0]); // 受信したデータを16ビットの整数に変換
-    // c言語のptrintfっぽいのをuartで垂れ流す
-    HAL_UART_Transmit(&huart1, (uint8_t *)&data, sizeof(data), 1000); // UARTにRxで受信したデータを流す
-    char a = '\n';
-    HAL_UART_Transmit(&huart1, (uint8_t *)&a, 1, 1000); // そのままだと改行がないためどこがはじめでどこが最後かわからなくなってしまうので改行をa(char)で垂れ流す。
+    printf("revceived data: %d\n", data);                             // 受信したデータintとしてUARTに出力（これで値が正しく表示されるはず）
   }
   /*
   //文字列用なのでコメントアウトしておきます

--- a/YamaHexDeviceController/Core/Src/retarget_io.c
+++ b/YamaHexDeviceController/Core/Src/retarget_io.c
@@ -1,0 +1,39 @@
+/**
+ * @file retarget_io.c
+ * @brief printf / scanf を huart1 にリターゲットする実装
+ *
+ * syscalls.c で weak 宣言された __io_putchar / __io_getchar を
+ * 強いシンボルとして定義することで、printf が UART1 に出力される。
+ */
+
+#include <stdint.h>
+
+#include "usart.h"
+
+// タイムアウト: 1 文字あたりの最大待機時間 [ms]
+#define UART_TIMEOUT_MS 100U
+
+/**
+ * @brief 1 文字を huart1 へ送信する (printf のリターゲット先)
+ * @param ch 送信する文字
+ * @return 送信した文字。失敗時は EOF (-1)
+ */
+int __io_putchar(int ch) {
+    uint8_t byte = (uint8_t)ch;
+    if (HAL_UART_Transmit(&huart1, &byte, 1U, UART_TIMEOUT_MS) != HAL_OK) {
+        return -1;
+    }
+    return ch;
+}
+
+/**
+ * @brief 1 文字を huart1 から受信する (scanf のリターゲット先)
+ * @return 受信した文字。失敗時は EOF (-1)
+ */
+int __io_getchar(void) {
+    uint8_t byte;
+    if (HAL_UART_Receive(&huart1, &byte, 1U, UART_TIMEOUT_MS) != HAL_OK) {
+        return -1;
+    }
+    return (int)byte;
+}

--- a/YamaHexDeviceController/cmake/stm32cubemx/CMakeLists.txt
+++ b/YamaHexDeviceController/cmake/stm32cubemx/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MX_Include_Dirs
 
 # STM32CubeMX generated application sources
 set(MX_Application_Src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/retarget_io.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/gpio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../Core/Src/can.c


### PR DESCRIPTION
#8 
ビルドがうまく行かなければ、buildディレクトリを消去後、再度ビルドしてください。